### PR TITLE
use sprockets to combine existing .js files so only one include is needed

### DIFF
--- a/public/ui/tasks/motion2d.html
+++ b/public/ui/tasks/motion2d.html
@@ -7,17 +7,13 @@
 
 
 <!-- GUI scripts and styles -->
-<link rel="stylesheet" href="../css/gui.css">
-<script src="../js/gui/Collapsable.js"></script>
+<link rel="stylesheet" href="css/taskgui.css">
 
-<!-- external js -->
+<!-- inclusion of .js files (each on it sown for debugging)  -->
+
+<!-- 
+
 <script src="../js/external/jquery-2.1.1.js"></script>
-
-
-<!-- own js and styles -->
-<link rel="stylesheet" type="text/css" media="screen" href="css/screen.css">
-<link rel="stylesheet" type="text/css" media="handheld" href="css/phone.css">
-
 <script src="../js/api/WebSock.js"></script>
 <script src="../js/api/JSON.js"></script>
 <script src="js/api/Typelib.js"></script>
@@ -25,6 +21,10 @@
 <script src="js/api/Tasks.js"></script>
 
 <script src="js/gui/motion2d.js"></script>
+
+-->
+
+<script src="/assets/js/taskgui.js"></script>
 
 
 <!-- 

--- a/public/ui/tasks/taskmanager.html
+++ b/public/ui/tasks/taskmanager.html
@@ -6,26 +6,24 @@
 
 <!-- theme -->
 <!-- download css themes on http://jqueryui.com/themeroller/ -->
-<!-- <link rel="stylesheet" type="text/css" href="css/jQueryUI/smoothness/jquery-ui.css"> -->
 <link rel="stylesheet" type="text/css" href="../css/jQueryUI/sunny/jquery-ui.css">
+<link rel="stylesheet" href="../js/external/jquery-jsonview/dist/jquery.jsonview.css" />
+
 
 <!-- GUI scripts and styles -->
-<link rel="stylesheet" href="../css/gui.css">
-<script src="../js/gui/Collapsable.js"></script>
+<link rel="stylesheet" href="/assets/css/taskgui.css">
 
-<!-- external libs -->
-<link rel="stylesheet" href="../js/external/jquery-jsonview/dist/jquery.jsonview.css" />
+
+
+
+<!-- inclusion of .js files (each on it sown for debugging)  -->
+
+<!--
+
+<script src="../js/gui/Collapsable.js"></script> 
 <script src="../js/external/jquery-2.1.1.js"></script>
 <script src="../js/external/jquery-ui.js"></script>
 <script type="text/javascript" src="../js/external/jquery-jsonview/dist/jquery.jsonview.js"></script>
-
-
-<!-- own libs and styles -->
-
-<link rel="stylesheet" type="text/css" media="screen" href="css/screen.css">
-<link rel="stylesheet" type="text/css" media="only screen and (max-device-width: 700px)" href="css/phone.css">
-
-
 <script src="../js/api/WebSock.js"></script>
 <script src="../js/api/JSON.js"></script>
 <script src="../js/api/Ruby/Unpack.js"></script>
@@ -34,16 +32,18 @@
 <script src="js/api/Ports.js"></script>
 <script src="js/api/Tasks.js"></script>
 <script src="js/gui/Forms.js"></script>
-
-
-<!-- ui elements -->
 <script src="js/gui/motion2d.js"></script>
 <script src="js/gui/frame.js"></script>
-
-<link rel="stylesheet" type="text/css" href="css/taskmanager.css">
 <script src="js/gui/taskmanager.js"></script>
-
 <script src="js/gui/GUIElements.js"></script>
+
+-->
+
+<!-- include using generated combined .js files -->
+<script src="/assets/js/taskgui.js"></script>
+
+
+
 
 <script>
 function init(){

--- a/ruby/webapp.rb.in
+++ b/ruby/webapp.rb.in
@@ -1,5 +1,20 @@
 plugin_path = "@CMAKE_SOURCE_DIR@/public" 
 
+#load dirs containing scripts
+environment.append_path File.join( '@CMAKE_SOURCE_DIR@' , 'public/ui/js')
+environment.append_path File.join( '@CMAKE_SOURCE_DIR@' , 'public/ui/tasks/js')
+environment.append_path File.join( '@CMAKE_SOURCE_DIR@' , 'public/ui/syskit/js')
+
+#load dirs containing css
+environment.append_path File.join( '@CMAKE_SOURCE_DIR@' , 'public/ui/css')
+environment.append_path File.join( '@CMAKE_SOURCE_DIR@' , 'public/ui/tasks/css')
+
+
+#load sprocket combined files
+environment.append_path File.join( '@CMAKE_SOURCE_DIR@' , 'sprockets')
+
+
+
 #map index page
 map '/' do
     run Rack::File.new( File.join(plugin_path, 'index.html') )

--- a/sprockets/css/taskgui.css
+++ b/sprockets/css/taskgui.css
@@ -1,0 +1,7 @@
+/**
+ * Sprockets include file to combine css
+ * =require gui.css
+ * =require phone.css
+ * =require screen.css
+ * =require taskmanager.css
+ */

--- a/sprockets/js/api.js
+++ b/sprockets/js/api.js
@@ -1,0 +1,14 @@
+
+/**
+ * Sprockets include file to combine api scrips
+ * =require external/jquery-2.1.1.js
+ * =require external/jquery-ui.js
+ * =require api/JSON.js
+ * =require api/Ruby/Unpack.js
+ * =require api/WebSock.js
+ * =require api/Load.js
+ */
+
+
+
+

--- a/sprockets/js/gui.js
+++ b/sprockets/js/gui.js
@@ -1,0 +1,8 @@
+
+/**
+ * Sprockets include file to combine api scrips
+ * =require external/jquery-jsonview/dist/jquery.jsonview.js
+ * =require gui/Buttons.js
+ * =require gui/Collapsable.js 
+ */
+

--- a/sprockets/js/syskitgui.js
+++ b/sprockets/js/syskitgui.js
@@ -1,0 +1,11 @@
+/**
+ * Sprockets include file to combine api scrips
+ * 
+ * sprocket combined
+ * =require js/api.js
+ * =require js/gui.js
+ * 
+ * sources
+ * =require gui/actions.js
+ * =require gui/Forms.js
+ */

--- a/sprockets/js/taskapi.js
+++ b/sprockets/js/taskapi.js
@@ -1,0 +1,14 @@
+
+/**
+ * Sprockets include file to combine api scrips
+ 
+ * sprocket combined
+ * =require js/api.js
+ * 
+ * sources
+ * =require api/Ports.js
+ * =require api/Typelib.js
+ * =require api/Tasks.js
+ */
+
+

--- a/sprockets/js/taskgui.js
+++ b/sprockets/js/taskgui.js
@@ -1,0 +1,14 @@
+/**
+ * Sprockets include file to combine api scrips
+ * 
+ * sprocket combined
+ * =require js/taskapi.js
+ * =require js/gui.js
+ * 
+ * sources
+ * =require gui/motion2d.js
+ * =require gui/GUIElements.js
+ * =require gui/frame.js
+ * =require gui/Forms.js
+ * =require gui/taskmanager.js
+ */


### PR DESCRIPTION
Use sprockets lib to combine existing .js files into a single include

The include order is correctly given by the filed including th libs

First the original .js iles are loaded into the sprockets env, then the additional files, which only include the first, ones are loaded.

Only a single .js file needs to be loaded in html

``` html
<script src="/assets/js/taskgui.js"></script>
```
